### PR TITLE
feature: add searchFilter option in ldap auth config file

### DIFF
--- a/src/controller/modules/ldapauth.js
+++ b/src/controller/modules/ldapauth.js
@@ -38,11 +38,12 @@ function* ldapQuery(username, password) {
       }
     });
 
-    search.on('searchReference', (referral) => {
-      if (referral) {
-        deferred.reject(referral);
-      }
-    });
+    // FIXME: do not reject when got searchReference
+    // search.on('searchReference', (referral) => {
+    //   if (referral) {
+    //     deferred.reject(referral);
+    //   }
+    // });
 
     search.on('end', () => {
       if (users.length > 0) {
@@ -69,9 +70,10 @@ function* ldapQuery(username, password) {
     }
 
     const searchDn = simpleParse([login.searchDn, login.baseDn].join(','), { username });
+    const searchFilter = simpleParse(login.searchFilter || '(objectclass=*)', { username });
 
     const opts = {
-      filter: '(objectclass=*)',
+      filter: searchFilter,
       scope: 'sub',
     };
 

--- a/src/controller/modules/ldapauth.js
+++ b/src/controller/modules/ldapauth.js
@@ -64,12 +64,12 @@ function* ldapQuery(username, password) {
     });
   };
 
-  client.bind([login.bindDn, login.baseDn].join(','), login.bindPassword, (err) => {
+  client.bind([login.bindDn, login.baseDn].filter(Boolean).join(','), login.bindPassword, (err) => {
     if (err) {
       deferred.reject(err);
     }
 
-    const searchDn = simpleParse([login.searchDn, login.baseDn].join(','), { username });
+    const searchDn = simpleParse([login.searchDn, login.baseDn].filter(Boolean).join(','), { username });
     const searchFilter = simpleParse(login.searchFilter || '(objectclass=*)', { username });
 
     const opts = {


### PR DESCRIPTION
LDAP 登录认证方式中添加 `searchFilter` 配置以适应更多的检索条件。
例如我们的项目是使用 `sAMAccountName` 来进行检索的。

**注意**：搜索时会触发 `searchReference` 事件，不清楚为什么要 reject，因此注释了这部分代码。